### PR TITLE
Add dark mode to the grid

### DIFF
--- a/css/picross.css
+++ b/css/picross.css
@@ -183,16 +183,32 @@ body.dark #puzzle td.key {
 	border-right: 1px solid #555;
 }
 
+body.dark #puzzle td:nth-child(5n + 1) {
+	border-right-color: #888;
+}
+
 #puzzle td.cell:nth-child(5n + 1) {
 	border-right: 1px solid #555;
+}
+
+body.dark #puzzle td.cell:nth-child(5n + 1) {
+	border-right-color: #888;
 }
 
 #puzzle tr:nth-child(5n + 1) td {
 	border-bottom: 1px solid #555;
 }
 
+body.dark #puzzle tr:nth-child(5n + 1) td {
+	border-bottom-color: #888;
+}
+
 #puzzle tr:nth-child(5n + 2) td {
 	border-top: 1px solid #555;
+}
+
+body.dark #puzzle tr:nth-child(5n + 2) td {
+	border-top-color: #888;
 }
 
 #puzzle td.key {
@@ -241,11 +257,21 @@ body.dark #puzzle td.key em {
 	vertical-align: middle;
 }
 
+body.dark #puzzle td.cell {
+	background-color: #333;
+	border-color: #555;
+}
+
 #puzzle td.cell.hoverLight {
 	background-color: #F7F2E0;
 }
 
-#puzzle td.cell.hover {
+body.dark #puzzle td.cell.hoverLight {
+	background-color: #444;
+}
+
+#puzzle td.cell.hover,
+body.dark #puzzle td.cell.hover {
 	background-color: #F7D358;
 }
 
@@ -254,12 +280,19 @@ body.dark #puzzle td.key em {
 	box-shadow: 0 0 5px 2px #ccc inset;
 }
 
-#puzzle td.cell.s2 {
+body.dark #puzzle td.cell.s1 {
+	background-color: #777;
+	box-shadow: 0 0 5px 2px #666 inset;
+}
+
+#puzzle td.cell.s2,
+body.dark #puzzle td.cell.s2 {
 	background-color: #81DAF5;
 	box-shadow: 0 0 5px 2px #01A9DB inset;
 }
 
-#puzzle td.cell.hover {
+#puzzle td.cell.hover,
+body.dark #puzzle td.cell.hover {
 	box-shadow: 0 0 5px 2px #FF8000 inset;
 }
 
@@ -284,4 +317,9 @@ body.dark #puzzle td.key em {
 #puzzle.complete.perfect td.cell.s2 {
 	background-color: transparent;
 	box-shadow: 1px 1px 5px #fff inset, -1px -1px 5px #666 inset;
+}
+
+body.dark #puzzle.complete.perfect td.cell.s2 {
+	background-color: transparent;
+	box-shadow: none;
 }


### PR DESCRIPTION
Hi, the new dark mode is a very welcome addition, so thanks for that!

However I think that we can make it even better by extending the dark mode to the actual grid as well. As it is right now it's a bit too bright compared to everything else in my opinion.

This PR is a proposal, I'm not sure if I covered all the cases so maybe some more testing is needed.

Here's before:
<img width="925" alt="Screenshot 2019-08-16 at 01 10 50" src="https://user-images.githubusercontent.com/13663338/63133111-f1eed580-bfc3-11e9-81cf-61bf0f27c68e.png">

And after:
<img width="925" alt="Screenshot 2019-08-16 at 01 17 47" src="https://user-images.githubusercontent.com/13663338/63133118-f6b38980-bfc3-11e9-97b3-e7c240ead864.png">

What do you think?